### PR TITLE
feat(docs): Adding the catalog-info.yaml file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,20 @@
+# For more information about the available options please visit: http://go/catalog-info (VPN required)
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: Unity-Technologies/patcher
+    backstage.io/techdocs-ref: dir:.
+  name: patcher
+  description: "Patcher is a GO library that provides a simple way to generate and SQL patches from structs. The library was built out of the need to generate patches for a database; when a new field is added to a struct, this would result in a bunch of new if checks to be created in the codebase. This library aims to solve that problem by generating the SQL patches for you."
+  labels:
+    costcenter: "5111"
+  links:
+    - url: https://unity.slack.com/messages/C8GB73GJK/
+      title: "#ask-multiplay"
+      icon: chat
+spec:
+  type: library
+  lifecycle: production
+  owner: unity-technologies/mps-senior-engineering
+


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

Applying the comment from Lewis in [this PR](https://github.com/Unity-Technologies/multiplay-go/pull/5157).

This pull request introduces a new catalog entry for the `patcher` component in the `catalog-info.yaml` file. The entry includes metadata, annotations, and specifications for the component.

Key changes include:

* Added metadata for the `patcher` component, including its name, description, and labels.
* Included annotations for GitHub project slug and TechDocs reference.
* Specified the component type as `library`, its lifecycle stage as `production`, and its owner as `unity-technologies/mps-senior-engineering`.